### PR TITLE
Fix for issue #5

### DIFF
--- a/check_mem.py
+++ b/check_mem.py
@@ -335,7 +335,7 @@ def main(options):
 
     version = execute_command(['free', '-V'])
     version_line = version.stdout.readline()
-    free_version = version_line.split()[3]
+    free_version = version_line.split()[-1]
 
     results = execute_command(['free', '-b'])
 


### PR DESCRIPTION
Allows the script to work with earlier versions of procps by using the last token in the version string rather than the fourth as originally coded.  This is still fragile but a little less so.

Run against procps  3.2.8:
```
>>> version = execute_command(['free', '-V'])
>>> version_line = version.stdout.readline()
>>> from pprint import pprint
>>> pprint(version)
<subprocess.Popen object at 0x7f05d9828310>
>>> pprint(version_line)
'procps version 3.2.8\n'
>>> version_line.split()[3]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: list index out of range
>>> version_line.split()
['procps', 'version', '3.2.8']
>>> version_line.split() [-1]
'3.2.8'
```

Run against procps-ng 3.3.9
```
>>> version = execute_command(['free', '-V'])
>>> version_line = version.stdout.readline()
>>> from pprint import pprint
>>> pprint(version_line)
'free from procps-ng 3.3.9\n'
>>> version_line.split() [-1]
'3.3.9'
>>> version_line.split() [3]
'3.3.9'
```
